### PR TITLE
test: added more tests for #53, #62

### DIFF
--- a/scripts/tests/tests.py
+++ b/scripts/tests/tests.py
@@ -303,7 +303,11 @@ items = [
     {"item": "ਨਾਉ ॥੪॥੨॥ ਸਿਰੀਰਾਗੁ ਮਹਲਾ ੧ ॥ ਲੇਖੈ", "description": "spaced"},
     {"item": "ਓਹੁ॥੧॥ਰਹਾਉ॥ਜੀਵਣ", "description": "without spaces"},
     {"item": "ਓਹੁ ॥੧॥ ਰਹਾਉ ॥ ਜੀਵਣ", "description": "spaced"},
-    {"item": 'ੴਸਤਿ ੴਵਾਹਿ ੴਹੁਕਮ (ੴ) "ੴ" ੴ 13', "description": "ੴ without spaces"},
-    {"item": 'ੴ ਸਤਿ ੴ ਵਾਹਿ ੴ ਹੁਕਮ ( ੴ ) " ੴ " ੴ 13', "description": "ੴ spaced"},
+    {"item": "ਭਾਗ॥ਆਦੇਸੁ", "description": "without spaces"},
+    {"item": "ਭਾਗ ॥ ਆਦੇਸੁ", "description": "spaced"},
+    {"item": "ਵਾਰ॥ਚੁਪੈ", "description": "without spaces"},
+    {"item": "ਵਾਰ ॥ ਚੁਪੈ", "description": "spaced"},
+    {"item": 'ੴਸਤਿ ੴਸ੍ਰੀ ੴਵਾਹਿ ੴਹੁਕਮ (ੴ) "ੴ" ੴ 13', "description": "ੴ without spaces"},
+    {"item": 'ੴ ਸਤਿ ੴ ਸ੍ਰੀ ੴ ਵਾਹਿ ੴ ਹੁਕਮ ( ੴ ) " ੴ " ੴ 13', "description": "ੴ spaced"},
 ]
 add_proof_sheet_test("doubledanda", "Double ਡੰਡਾ/ਹੱਦ character (॥)  #53", items)


### PR DESCRIPTION
<!-- Please title as if this PR were a single commit to our main branch. -->
<!-- https://docs.shabados.com/community/coding-guidelines#commit-messages -->
<!-- Also don't forget to add any reviewer(s) and link the related issue! -->

### Summary

This PR updates the test for Double Danda (which also consolidates tests for various word combination that use `ੴ`).

It adds the following:
- a test for `ੴ` followed by a letter containing `ੀ` - the two characters overlap slightly
for: #62

- tests for `॥` when it is preceded by either a `ਰ` or `ਗ` - the vertical line in `॥` closely resembles the vertical line in `ਗ`
for: #53 

### Test
- `hatch run qa`

### Duration
